### PR TITLE
Markdown format fix for the example base64 command

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -11,7 +11,7 @@ description: |
   After building the VPN server, you need to register the contents of CA certificate, client certificate, client private key, base64 encoded as Bitrise Secret.
   You can easily retrieve the contents of Base64 with the following command.
 
-  # base64 <certificate or private key file path>
+  `# base64 <certificate or private key file path>`
 website: https://github.com/justice3120/bitrise-step-open-vpn
 source_code_url: https://github.com/justice3120/bitrise-step-open-vpn
 support_url: https://github.com/justice3120/bitrise-step-open-vpn/issues


### PR DESCRIPTION
Otherwise in markdown if the line starts with `#` it will be a "level one header" :)